### PR TITLE
fix: make audio work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,3 +14,4 @@ RUN set -eux; \
     echo "neko ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/neko 
 
 COPY supervisord.conf /etc/neko/supervisord/xfce4.conf
+COPY default.pa /etc/pulse/default.pa

--- a/default.pa
+++ b/default.pa
@@ -1,0 +1,7 @@
+#!/usr/bin/pulseaudio -nF
+
+# Allow pulse audio to be accessed via TCP (from localhost only), to allow other users to access the virtual devices
+load-module module-native-protocol-unix socket=/tmp/pulseaudio.socket auth-anonymous=1
+
+### Make sure we always have a sink around, even if it is a null sink.
+load-module module-always-sink


### PR DESCRIPTION
For me, audio was not working at all when I set this image up. I realized that the default.pa file was not like the one thats provided by neko/deps.

This change makes sure audio works again by re-applying the default.pa pulseaudio file which is presumably lost somewhere along the way.